### PR TITLE
docs: update README with pipeline description and correct input format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,46 +21,41 @@
 
 ## Introduction
 
-**nf-core/antibodyoptimization** is a bioinformatics pipeline that ...
+**nf-core/antibodyoptimization** is a bioinformatics pipeline for end-to-end antibody optimization. It takes an antibody structure in PDB format as input and produces redesigned, structurally verified, and humanized antibody sequences with OASis humanness scores.
 
-<!-- TODO nf-core:
-   Complete this sentence with a 2-3 sentence summary of what types of data the pipeline ingests, a brief overview of the
-   major pipeline sections and the types of output it produces. You're giving an overview to someone new
-   to nf-core here, in 15-20 seconds. For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#introduction
--->
+The pipeline runs four stages in sequence:
 
-<!-- TODO nf-core: Include a figure that guides the user through the major workflow steps. Many nf-core
-     workflows use the "tube map" design for that. See https://nf-co.re/docs/guidelines/graphic_design/workflow_diagrams#examples for examples.   -->
-<!-- TODO nf-core: Fill in short bullet-pointed list of the default steps in the pipeline -->2. Present QC for raw reads ([`MultiQC`](http://multiqc.info/))
+1. **[AntiFold](https://github.com/oxpig/AntiFold)** — CDR redesign via inverse folding, producing redesigned sequence candidates
+2. **[ABodyBuilder2](https://github.com/oxpig/ImmuneBuilder)** — structure prediction for each candidate
+3. **[BioPhi Sapiens](https://github.com/Merck/BioPhi)** — sequence humanization
+4. **[OASis](https://github.com/Merck/BioPhi)** — humanness scoring against observed antibody space
 
 ## Usage
 
 > [!NOTE]
 > If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/usage/introduction#how-to-run-a-pipeline) with `-profile test` before running the workflow on actual data.
 
-<!-- TODO nf-core: Describe the minimum required steps to execute the pipeline, e.g. how to prepare samplesheets.
-     Explain what rows and columns represent. For instance (please edit as appropriate):
-
-First, prepare a samplesheet with your input data that looks as follows:
+First, prepare a samplesheet with your input data:
 
 `samplesheet.csv`:
 
 ```csv
-sample,fastq_1,fastq_2
-CONTROL_REP1,AEG588A1_S1_L002_R1_001.fastq.gz,AEG588A1_S1_L002_R2_001.fastq.gz
+sample,pdb,chain_heavy,chain_light
+Ab001,/path/to/Ab001.pdb,H,L
 ```
 
-Each row represents a fastq file (single-end) or a pair of fastq files (paired end).
-
--->
+| Column | Description |
+|---|---|
+| `sample` | Unique sample identifier |
+| `pdb` | Path to the antibody structure file (PDB format, IMGT-numbered) |
+| `chain_heavy` | Chain ID of the heavy chain in the PDB file |
+| `chain_light` | Chain ID of the light chain in the PDB file |
 
 Now, you can run the pipeline using:
 
-<!-- TODO nf-core: update the following command to include all required parameters for a minimal example -->
-
 ```bash
 nextflow run nf-core/antibodyoptimization \
-   -profile <docker/singularity/.../institute> \
+   -profile docker \
    --input samplesheet.csv \
    --outdir <OUTDIR>
 ```
@@ -106,51 +101,3 @@ You can cite the `nf-core` publication as follows:
 > Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.
 >
 > _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).
-
-
-# Go to repo on the EC2 instance
-cd ~/nf-core-antibody-pipeline
-# Build the Docker image (uses Dockerfile in this repo)
-sudo docker build -t howlinman/biophi-oasis:latest .# Ensure the OASis DB is available on the host
-ls /data/oasis
-# expected: OASis_9mers_v1.db or OASis_9mers_v1.db.gz# If the DB is gzipped, uncompress once
-cd /data/oasis
-sudo gunzip OASis_9mers_v1.db.gz
-
-# Quick Sapiens test: create a small FASTA
-cd ~/nf-core-antibody-pipeline
-
-cat > test.fa << 'EOF'
->test_ab_heavy
-EVQLVESGGGLVQPGGSLRLSCAASGFTFSSYAMSWVRQAPGKGLEWVSAISGSGGSTYYADSVK
-GRFTISRDNAKNTVYLQMNSLKPEDTAVYYCARGGYYGMDYWGQGTLVTVSS
-EOF
-
-# Run Sapiens humanization (writes humanized.fa)
-sudo docker run --rm -it \
-  -u $(id -u):$(id -g) \
-  -v "$PWD":/work \
-  howlinman/biophi-oasis:latest \
-  biophi sapiens /work/test.fa \
-    --fasta-only \
-    --output /work/humanized.fa
-
-# Quick OASis test: create example FASTA
-cd ~/nf-core-antibody-pipeline
-
-cat > my_real_data.fa << 'EOF'
->example_antibody
-EVQLVESGGGLVQPGGSLRLSCAASGFTFSSYAMSWVRQAPGKGLEWVSAISGSGGSTYYADSVK
-GRFTISRDNAKNTVYLQMNSLKPEDTAVYYCARGGYYGMDYWGQGTLVTVSS
-EOF
-
-# Run OASis with DB mounted from /data/oasis
-sudo docker run --rm -it \
-  -u $(id -u):$(id -g) \
-  -v "$PWD":/work \
-  -v /data/oasis:/data/oasis \
-  howlinman/biophi-oasis:latest \
-  biophi oasis /work/my_real_data.fa \
-    --output /work/my_real_oasis_report.xlsx \
-    --oasis-db /data/oasis/OASis_9mers_v1.db
-

--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ nextflow run nf-core/antibodyoptimization \
 
 For more details and further functionality, please refer to the [usage documentation](https://nf-co.re/antibodyoptimization/usage) and the [parameter documentation](https://nf-co.re/antibodyoptimization/parameters).
 
+## Testing
+
+A minimal test profile is provided that runs the pipeline against a pre-staged antibody structure ([6Y1L](https://www.rcsb.org/structure/6Y1L), IMGT-numbered).
+
+**Stub run** (no containers required, validates workflow logic only):
+
+```bash
+nextflow run . -profile test,docker --outdir ./results -stub
+```
+
+**Full test run** (requires the test PDB to be available on the host at `/data/antifold/pdbs/6y1l_imgt.pdb`):
+
+```bash
+nextflow run . -profile test,docker --outdir ./results
+```
+
+The test samplesheet (`assets/samplesheet_test.csv`) uses chain IDs `H` (heavy) and `L` (light).
+
 ## Pipeline output
 
 To see the results of an example test run with a full size dataset refer to the [results](https://nf-co.re/antibodyoptimization/results) tab on the nf-core website pipeline page.


### PR DESCRIPTION
## Summary

- Replace nf-core template TODOs with actual pipeline description
- Document four-stage workflow: AntiFold → ABodyBuilder2 → BioPhi → OASis
- Update samplesheet example from FASTQ to PDB format with column description table
- Remove accidentally committed Docker test commands from bottom of file

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Samplesheet example matches `assets/samplesheet.csv` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)