### PR TITLE
docs: update README and pipeline architecture with correct stage order and filtering

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,13 +51,21 @@ PDB input (antibody structure)
    ↓
 AntiFold          — CDR redesign via inverse folding → redesigned FASTA candidates
    ↓
-ABodyBuilder2     — structure prediction → PDB per candidate
+FILTER_ANTIFOLD   — CDR log-odds score (AntiFold `score` field) > threshold (user-defined)
    ↓
 BioPhi Sapiens    — humanization → humanized sequences
    ↓
+FILTER_BIOPHI     — Sapiens humanness score ≥ 0.8
+   ↓
+ABodyBuilder2     — structure prediction → PDB per humanized candidate
+   ↓
+FILTER_ABODYBUILDER2 — mean CDR B-factor error < 1.5 Å AND Cα CDR RMSD to input PDB < 2.0 Å
+   ↓
 OASis             — humanness scoring against observed antibody space
    ↓
-results/ (ranked candidates: sequences + humanness scores)
+RANK_OASIS        — rank by OASis percentile (0–100); exclude extreme outliers below params.oasis_min_percentile (default: 10)
+   ↓
+results/ (ranked candidates: sequences + OASis humanness scores)
 ```
 
 ### Channel Contract
@@ -67,12 +75,19 @@ Preserve these channel shapes at module boundaries:
 | Boundary | Channel shape |
 |---|---|
 | Input → AntiFold | `tuple val(meta), path(pdb)` |
-| AntiFold → ABodyBuilder2 | `tuple val(meta), path(redesigned_fasta)` |
-| ABodyBuilder2 → BioPhi | `tuple val(meta), path(predicted_pdb)` |
-| BioPhi → OASis | `tuple val(meta), path(humanized_fasta)` |
+| AntiFold → FILTER_ANTIFOLD | `tuple val(meta), path(redesigned_fasta), path(scores_csv)` |
+| FILTER_ANTIFOLD → BioPhi | `tuple val(meta), path(redesigned_fasta)` |
+| BioPhi → FILTER_BIOPHI | `tuple val(meta), path(humanized_fasta), path(sapiens_scores_csv)` |
+| FILTER_BIOPHI → ABodyBuilder2 | `tuple val(meta), path(humanized_fasta)` |
+| ABodyBuilder2 → FILTER_ABODYBUILDER2 | `tuple val(meta), path(predicted_pdb)` joined with original `path(input_pdb)` via `meta.id` |
+| FILTER_ABODYBUILDER2 → OASis | `tuple val(meta), path(predicted_pdb)` |
+| OASis → RANK_OASIS | `tuple val(meta), path(oasis_scores_csv)` |
+| RANK_OASIS → output | `tuple val(meta), path(ranked_scores_csv)` |
 
 The `meta` map MUST contain at minimum: `id`, `sample`, `chain_heavy`, `chain_light`.
 Do not add meta fields without updating all affected modules.
+
+Score files are used by filter modules for inter-stage filtering and published to `results/` as-is. Do not embed scores in the `meta` map. The original input PDB must be carried as a separate channel and joined by `meta.id` at `FILTER_ABODYBUILDER2`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,26 @@
 The pipeline runs four stages in sequence:
 
 1. **[AntiFold](https://github.com/oxpig/AntiFold)** — CDR redesign via inverse folding, producing redesigned sequence candidates
-2. **[ABodyBuilder2](https://github.com/oxpig/ImmuneBuilder)** — structure prediction for each candidate
-3. **[BioPhi Sapiens](https://github.com/Merck/BioPhi)** — sequence humanization
+2. **[BioPhi Sapiens](https://github.com/Merck/BioPhi)** — sequence humanization
+3. **[ABodyBuilder2](https://github.com/oxpig/ImmuneBuilder)** — structure prediction for each humanized candidate
 4. **[OASis](https://github.com/Merck/BioPhi)** — humanness scoring against observed antibody space
+
+### Filtering
+
+The pipeline applies quality filters between stages to reduce the candidate set before each computationally expensive step:
+
+| Stage transition | Module | Metric | Description | Default threshold |
+|---|---|---|---|---|
+| AntiFold → BioPhi | `FILTER_ANTIFOLD` | `--antifold_min_score` | `score` field in AntiFold FASTA header: average log-odds across CDR positions; higher (less negative) = better sequence–structure fit | user-defined |
+| BioPhi → ABodyBuilder2 | `FILTER_BIOPHI` | `--sapiens_min_score` | Mean Sapiens humanness score per sequence (0–1); filters poorly humanized candidates before structure prediction | `≥ 0.8` |
+| ABodyBuilder2 → OASis | `FILTER_ABODYBUILDER2` | `--abodybuilder2_max_error` | Mean per-residue error estimate across CDR positions from ABodyBuilder2 B-factor column (Å, ensemble disagreement); lower = more confident prediction | `< 1.5` |
+| ABodyBuilder2 → OASis | `FILTER_ABODYBUILDER2` | `--abodybuilder2_max_rmsd` | Cα RMSD of CDR regions between ABodyBuilder2-predicted structure and original input PDB (Å); ensures humanized sequence retains the parent fold | `< 2.0` |
+| OASis → output | `RANK_OASIS` | `--oasis_min_percentile` | OASis percentile (0–100), calibrated against 544 therapeutic mAbs: human mAbs median ~80, humanized ~37, murine ~5; candidates are ranked by percentile and only extreme outliers excluded | `≥ 10` |
+
+> [!NOTE]
+> `--antifold_min_score` has no hardcoded default as the appropriate threshold is antibody-dependent. All other thresholds are suggested defaults and can be overridden at runtime.
+>
+> OASis percentile is used for **ranking**, not hard filtering. A minimum percentile of 10 excludes only extreme outliers (murine-like sequences). Do not use OASis score alone as an acceptance/rejection criterion — humanness does not directly predict clinical immunogenicity.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Corrects the pipeline stage order to: AntiFold → BioPhi → ABodyBuilder2 → OASis
- Documents four inter-stage filter/rank modules with verified metrics
- Updates channel contract in `copilot-instructions.md` to match new order

## Changes

### README
- Corrected pipeline stage order
- Added **Filtering** section documenting all four inter-stage filter modules, parameters, and default thresholds
- Added note that `--antifold_min_score` has no hardcoded default (antibody-dependent)
- Documents `RANK_OASIS` as a ranking step, not a hard filter, with explanation

### copilot-instructions.md
- Updated pipeline stage diagram with filter steps inline
- Updated channel contract table to reflect new stage order and score file outputs
- Clarified that original input PDB must be joined by `meta.id` at `FILTER_ABODYBUILDER2`

## Filter modules (tracked in separate issues)

| Module | Parameter | Metric | Default |
|---|---|---|---|
| `FILTER_ANTIFOLD` | `--antifold_min_score` | AntiFold `score` field (CDR log-odds) | user-defined |
| `FILTER_BIOPHI` | `--sapiens_min_score` | Sapiens humanness score (0–1) | `≥ 0.8` |
| `FILTER_ABODYBUILDER2` | `--abodybuilder2_max_error` | Mean CDR B-factor error in Å | `< 1.5` |
| `FILTER_ABODYBUILDER2` | `--abodybuilder2_max_rmsd` | Cα CDR RMSD to input PDB (Å) | `< 2.0` |
| `RANK_OASIS` | `--oasis_min_percentile` | OASis percentile (0–100) | `≥ 10` |

## Related issues

- #36 FILTER_ANTIFOLD
- #40 FILTER_BIOPHI
- #41 FILTER_ABODYBUILDER2
- #42 RANK_OASIS

🤖 Generated with [Claude Code](https://claude.com/claude-code)